### PR TITLE
Translate log messages to English

### DIFF
--- a/src/main/java/com/habit/client/HomeController.java
+++ b/src/main/java/com/habit/client/HomeController.java
@@ -214,13 +214,12 @@ public class HomeController {
             });
           }
         } catch (NumberFormatException e) {
-          logger.error("サボりポイントの解析に失敗しました: {}", body);
+          logger.error("Failed to parse sabotage points: {}", body);
           level = 0; // エラー時は最低レベル
         }
       }
     } catch (Exception ex) {
-      logger.error("サボりポイントの取得に失敗しました: {}", ex.getMessage(),
-                   ex);
+      logger.error("Failed to retrieve sabotage points: {}", ex.getMessage(), ex);
       level = 0; // エラー時は最低レベル
     }
 
@@ -234,7 +233,7 @@ public class HomeController {
             new Image(getClass().getResource(framePath).toExternalForm());
         animationFrames.add(frameImage);
       } catch (Exception e) {
-        logger.error("アニメーションフレームの読み込み失敗: " + framePath);
+        logger.error("Failed to load animation frame: " + framePath);
       }
     }
 
@@ -256,7 +255,7 @@ public class HomeController {
             new Image(getClass().getResource(fallbackPath).toExternalForm());
         teamCharView.setImage(fallbackImage);
       } catch (NullPointerException e) {
-        logger.error("フォールバック画像も見つかりません: " + fallbackPath);
+        logger.error("Fallback image not found: " + fallbackPath);
       }
     }
 

--- a/src/main/java/com/habit/client/PersonalPageController.java
+++ b/src/main/java/com/habit/client/PersonalPageController.java
@@ -110,7 +110,7 @@ public class PersonalPageController {
                     // タスク完了処理（API経由）
                     try {
                         if (userId == null || userId.isEmpty()) {
-                            logger.error("エラー: userIdが未設定です。タスク完了処理を中止します。");
+                            logger.error("Error: userId is not set. Aborting task completion.");
                             return;
                         }
                         String taskId = task.getTaskId();
@@ -129,7 +129,7 @@ public class PersonalPageController {
                                 .POST(java.net.http.HttpRequest.BodyPublishers.ofString(params))
                                 .build();
                         java.net.http.HttpResponse<String> response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString());
-                        logger.info("タスク完了APIレスポンス: {}", response.body());
+                        logger.info("Task completion API response: {}", response.body());
                         
                         // タスク完了成功の場合のみタイル一覧を再読み込み
                         if (response.statusCode() == 200) {
@@ -141,9 +141,9 @@ public class PersonalPageController {
                                         try {
                                             this.tasks = fetchUserTasksForPersonalPage();
                                             updateTaskTiles();
-                                            logger.info("個人ページのタスク一覧を更新しました");
+                                            logger.info("Updated personal page task list");
                                         } catch (Exception ex) {
-                                            logger.error("タスク一覧更新エラー: {}", ex.getMessage(), ex);
+                                            logger.error("Failed to update task list: {}", ex.getMessage(), ex);
                                         }
                                     });
                                 } catch (InterruptedException ie) {
@@ -151,13 +151,13 @@ public class PersonalPageController {
                                 }
                             }).start();
                         } else {
-                            logger.error("タスク完了APIエラー: statusCode={}", response.statusCode());
+                            logger.error("Task completion API error: statusCode={}", response.statusCode());
                         }
                         return;
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
-                    logger.info("タスク選択: {}", name);
+                    logger.info("Task selected: {}", name);
                 }
             });
             taskTilePane.getChildren().add(tileBtn);
@@ -171,7 +171,7 @@ public class PersonalPageController {
         
         // 期限日付が指定されていない場合は今日として扱う
         if (dueDate == null) {
-            logger.info("期限日がnullです。");
+            logger.info("Due date is null.");
             return null;
         }
         

--- a/src/main/java/com/habit/client/SearchTeamController.java
+++ b/src/main/java/com/habit/client/SearchTeamController.java
@@ -180,9 +180,8 @@ public class SearchTeamController {
                 return teamId.trim();
             }
         } catch (Exception ex) {
-            logger.error("チームID取得エラー: {}", ex.getMessage(), ex);
+            logger.error("Failed to get team ID: {}", ex.getMessage(), ex);
         }
         // 取得できない場合はパスコードをフォールバックとして使用
         return passcode;
-    }
-}
+    }}

--- a/src/main/java/com/habit/client/TaskCreateController.java
+++ b/src/main/java/com/habit/client/TaskCreateController.java
@@ -118,7 +118,7 @@ public class TaskCreateController {
             return;
         }
         // ログ出力
-        logger.info("タスク作成: " +
+        logger.info("Creating task: " +
             "taskId=" + task.getTaskId() +
             ", name=" + task.getTaskName() +
             ", description=" + task.getDescription() +
@@ -141,7 +141,7 @@ public class TaskCreateController {
                 .POST(HttpRequest.BodyPublishers.ofString(body))
                 .build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            logger.info("タスク保存APIレスポンス: " + response.body());
+            logger.info("Task save API response: " + response.body());
         } catch (Exception e) {
             showAlert("タスク保存APIエラー: " + e.getMessage());
             return;

--- a/src/main/java/com/habit/client/TeamTopController.java
+++ b/src/main/java/com/habit/client/TeamTopController.java
@@ -182,12 +182,12 @@ public class TeamTopController {
           }
 
         } catch (NumberFormatException e) {
-          logger.error("サボりポイントの解析に失敗しました: " + body);
+          logger.error("Failed to parse sabotage points: " + body);
           level = 0; // エラー時は最低レベル
         }
       }
     } catch (Exception ex) {
-      logger.error("サボりポイントの取得に失敗しました: " + ex.getMessage());
+      logger.error("Failed to retrieve sabotage points: " + ex.getMessage());
       level = 0; // エラー時は最低レベル
     }
 
@@ -199,7 +199,7 @@ public class TeamTopController {
             new Image(getClass().getResource(framePath).toExternalForm());
         animationFrames.add(frameImage);
       } catch (Exception e) {
-        logger.error("アニメーションフレームの読み込み失敗: " + framePath);
+        logger.error("Failed to load animation frame: " + framePath);
       }
     }
 
@@ -221,7 +221,7 @@ public class TeamTopController {
             new Image(getClass().getResource(fallbackPath).toExternalForm());
         teamCharView.setImage(fallbackImage);
       } catch (NullPointerException e) {
-        logger.error("フォールバック画像も見つかりません: " + fallbackPath);
+        logger.error("Fallback image not found: " + fallbackPath);
       }
     }
 

--- a/src/main/java/com/habit/server/HabitServer.java
+++ b/src/main/java/com/habit/server/HabitServer.java
@@ -221,32 +221,32 @@ public class HabitServer {
 
     // 自動実行スケジューラーを開始
     try {
-      logger.info("タスク自動再設定スケジューラーを開始します...");
+      logger.info("Starting task auto reset scheduler...");
       taskAutoResetScheduler.start();
-      logger.info("タスク自動再設定スケジューラーが正常に開始されました。");
+      logger.info("Task auto reset scheduler started successfully.");
     } catch (Exception e) {
-      logger.error("タスク自動再設定スケジューラーの開始に失敗しました: {}",
+      logger.error("Failed to start task auto reset scheduler: {}",
                    e.getMessage(), e);
       // スケジューラーが失敗してもサーバー自体は起動を継続
     }
 
     // サーバーシャットダウン時の処理を登録
     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-      logger.info("サーバをシャットダウンしています...");
+      logger.info("Shutting down server...");
       // スケジューラーを安全に停止
       taskAutoResetScheduler.stop();
       // HTTPサーバーを停止
       server.stop(0);
     }));
 
-    logger.info("サーバが起動しました: {}", Config.getServerUrl());
-    logger.info("タスク自動再設定機能が有効になりました");
+    logger.info("Server started at: {}", Config.getServerUrl());
+    logger.info("Task auto reset enabled");
 
     if (is_debug) {
       logger.info(
-          "手動実行API: /manualTaskReset, /manualTaskResetTeam?teamId=xxx");
+          "Manual run API: /manualTaskReset, /manualTaskResetTeam?teamId=xxx");
       logger.info(
-          "デバッグAPI: /debugScheduledReset?delay=秒数, /debugSabotageReport");
+          "Debug API: /debugScheduledReset?delay=seconds, /debugSabotageReport");
     }
   }
 }

--- a/src/main/java/com/habit/server/controller/AuthController.java
+++ b/src/main/java/com/habit/server/controller/AuthController.java
@@ -67,7 +67,7 @@ public class AuthController {
           var user = authService.getUserBySession(sessionId);
           if (user != null) {
             logger.info(
-                "ログインユーザ情報: userId={} , username={} , sabotagePoints={} , joinedTeamIds={}",
+                "Logged in user info: userId={} , username={} , sabotagePoints={} , joinedTeamIds={}",
                 user.getUserId(),
                 user.getUsername(),
                 user.getSabotagePoints(),
@@ -125,7 +125,7 @@ public class AuthController {
           var user = authService.getUserBySession(sessionId);
           if (user != null) {
             logger.info(
-                "新規登録ユーザ情報: userId={} , username={} , sabotagePoints={} , joinedTeamIds={}",
+                "Registered user info: userId={} , username={} , sabotagePoints={} , joinedTeamIds={}",
                 user.getUserId(),
                 user.getUsername(),
                 user.getSabotagePoints(),

--- a/src/main/java/com/habit/server/controller/MessageController.java
+++ b/src/main/java/com/habit/server/controller/MessageController.java
@@ -155,13 +155,13 @@ public class MessageController {
       messageRepository.save(message);
 
       logger.info(
-          "[チャット] teamID={} , senderId={} , username={} , content={}",
+          "[Chat] teamID={} , senderId={} , username={} , content={}",
           teamID,
           senderId,
           sender.getUsername(),
           content);
 
-      respond(exchange, 200, "チャット送信成功");
+      respond(exchange, 200, "Message sent successfully");
     }
   }
 }

--- a/src/main/java/com/habit/server/controller/TeamController.java
+++ b/src/main/java/com/habit/server/controller/TeamController.java
@@ -233,9 +233,9 @@ public class TeamController {
               // 新メンバーに既存のチーム共通タスクを自動紐づけ
               try {
                 teamTaskService.createUserTaskStatusForNewMember(teamID, memberId);
-                logger.info("新メンバー {} にチーム {} の既存タスクを紐づけました", memberId, teamID);
+                logger.info("Linked existing team tasks to new member {} in team {}", memberId, teamID);
               } catch (Exception e) {
-                logger.error("チーム共通タスクの自動紐づけに失敗: {}", e.getMessage(), e);
+                logger.error("Failed to link common team tasks: {}", e.getMessage(), e);
               }
             }
           }

--- a/src/main/java/com/habit/server/controller/TeamTaskController.java
+++ b/src/main/java/com/habit/server/controller/TeamTaskController.java
@@ -64,7 +64,7 @@ public class TeamTaskController {
                                 break;
                         }
                     } catch (Exception e) {
-                        logger.error("パラメータ解析エラー: {}", e.getMessage(), e);
+                        logger.error("Parameter parse error: {}", e.getMessage(), e);
                     }
                 }
             }
@@ -115,7 +115,7 @@ public class TeamTaskController {
                                 break;
                         }
                     } catch (Exception e) {
-                        logger.error("パラメータ解析エラー: {}", e.getMessage(), e);
+              logger.error("Parameter parse error: {}", e.getMessage(), e);
                     }
                 }
             }

--- a/src/main/java/com/habit/server/controller/UserTaskStatusController.java
+++ b/src/main/java/com/habit/server/controller/UserTaskStatusController.java
@@ -401,10 +401,10 @@ public class UserTaskStatusController {
                             int newPoints = Math.max(0, currentPoints - 1); // 0未満にはしない
                             user.setSabotagePoints(newPoints);
                             userRepo.save(user);
-                            logger.info("タスク完了によりサボりポイント更新: {} {}pt → {}pt", user.getUsername(), currentPoints, newPoints);
+                        logger.info("Updated sabotage points on task completion: {} {}pt -> {}pt", user.getUsername(), currentPoints, newPoints);
                         }
                     } catch (Exception e) {
-                        logger.error("サボりポイント更新エラー: {}", e.getMessage(), e);
+                    logger.error("Error updating sabotage points: {}", e.getMessage(), e);
                     }
                     
                     response = "タスク完了: userId=" + userId[0] + ", taskId=" + taskId[0] + ", date=" + dateStr;

--- a/src/main/java/com/habit/server/repository/TaskRepository.java
+++ b/src/main/java/com/habit/server/repository/TaskRepository.java
@@ -68,7 +68,7 @@ public class TaskRepository {
       }
       if (hasTask && !hasTaskName) {
         // SQLiteは直接カラム名変更できないため、手動で対応が必要
-        logger.warn("注意: tasksテーブルのカラム 'task' を 'taskName' にリネームしてください。");
+        logger.warn("Please rename the 'task' column to 'taskName' in the tasks table.");
       }
 
       // ユーザーごとのタスク達成状況

--- a/src/main/java/com/habit/server/scheduler/TaskAutoResetScheduler.java
+++ b/src/main/java/com/habit/server/scheduler/TaskAutoResetScheduler.java
@@ -35,11 +35,11 @@ public class TaskAutoResetScheduler {
         long initialDelay = now.until(nextRun, ChronoUnit.SECONDS); // 初回実行までの遅延（秒単位）
         long period = TimeUnit.DAYS.toSeconds(1); // 24時間
 
-        logger.info("=== タスク自動再設定スケジューラー初期化 ===");
-        logger.info("現在時刻: " + now);
-        logger.info("次回実行予定: " + nextRun);
-        logger.info("初回実行まで: " + initialDelay + "秒 (" + (initialDelay / 3600) + "時間" + ((initialDelay % 3600) / 60) + "分)");
-        logger.info("実行間隔: 24時間ごと");
+        logger.info("=== Initializing Task Auto Reset Scheduler ===");
+        logger.info("Current time: " + now);
+        logger.info("Next run: " + nextRun);
+        logger.info("Initial delay: " + initialDelay + " seconds (" + (initialDelay / 3600) + "h" + ((initialDelay % 3600) / 60) + "m)");
+        logger.info("Execution interval: every 24 hours");
 
         try {
             scheduler.scheduleAtFixedRate(
@@ -49,15 +49,15 @@ public class TaskAutoResetScheduler {
                 TimeUnit.SECONDS        // 時間単位
             );
             
-            logger.info("[SUCCESS] タスク自動再設定スケジューラーを正常に開始しました。");
+            logger.info("[SUCCESS] Task auto reset scheduler started successfully.");
             
         } catch (Exception e) {
-            logger.error("[ERROR] タスク自動再設定スケジューラーの開始に失敗しました: " + e.getMessage());
+            logger.error("[ERROR] Failed to start task auto reset scheduler: " + e.getMessage());
             e.printStackTrace();
             throw e; // 初期化失敗を上位に伝える
         }
         
-        logger.info("=== スケジューラー初期化完了 ===");
+        logger.info("=== Scheduler initialization complete ===");
     }
     
     /**
@@ -79,7 +79,7 @@ public class TaskAutoResetScheduler {
         } catch (InterruptedException e) {
             scheduler.shutdownNow(); // 割り込み時も強制終了
         }
-        logger.info("タスク自動再設定スケジューラーを停止しました。");
+        logger.info("Task auto reset scheduler stopped.");
     }
     
     /**
@@ -89,31 +89,31 @@ public class TaskAutoResetScheduler {
      */
     private void executeAutoReset() {
         LocalDateTime startTime = LocalDateTime.now();
-        logger.info("=== タスク自動再設定を開始 ===");
-        logger.info("開始時刻: " + startTime);
-        logger.info("スレッド: " + Thread.currentThread().getName());
+        logger.info("=== Starting task auto reset ===");
+        logger.info("Start time: " + startTime);
+        logger.info("Thread: " + Thread.currentThread().getName());
         
         try {
             // メイン処理を実行
             taskAutoResetService.runScheduledCheck();
             
             LocalDateTime endTime = LocalDateTime.now();
-            logger.info("=== タスク自動再設定を正常完了 ===");
-            logger.info("完了時刻: " + endTime);
-            logger.info("処理時間: " + java.time.Duration.between(startTime, endTime).toMillis() + "ms");
+            logger.info("=== Task auto reset completed successfully ===");
+            logger.info("End time: " + endTime);
+            logger.info("Elapsed time: " + java.time.Duration.between(startTime, endTime).toMillis() + "ms");
             
         } catch (Exception e) {
             LocalDateTime errorTime = LocalDateTime.now();
-            logger.error("=== タスク自動再設定でエラーが発生 ===");
-            logger.error("エラー発生時刻: " + errorTime);
-            logger.error("エラー内容: " + e.getMessage());
-            logger.error("スタックトレース:");
+            logger.error("=== Error occurred during task auto reset ===");
+            logger.error("Error time: " + errorTime);
+            logger.error("Error: " + e.getMessage());
+            logger.error("Stack trace:");
             e.printStackTrace();
             
             // エラー後も次回実行を継続するため、ここで例外を再スローしない
         }
         
-        logger.info("=== タスク自動再設定処理終了 ===");
+        logger.info("=== Task auto reset process finished ===");
     }
     
     /**
@@ -137,14 +137,14 @@ public class TaskAutoResetScheduler {
      * @param delaySeconds 実行までの遅延秒数
      */
     public void scheduleTestExecution(int delaySeconds) {
-        logger.info("=== デバッグ用テスト実行をスケジュール ===");
-        logger.info("実行予定: " + delaySeconds + "秒後");
-        logger.info("予定時刻: " + LocalDateTime.now().plusSeconds(delaySeconds));
+        logger.info("=== Scheduling debug test run ===");
+        logger.info("Scheduled to run after " + delaySeconds + " seconds");
+        logger.info("Scheduled time: " + LocalDateTime.now().plusSeconds(delaySeconds));
         
         scheduler.schedule(() -> {
-            logger.info("=== デバッグ用テスト実行開始 ===");
+            logger.info("=== Debug test run started ===");
             executeAutoReset();
-            logger.info("=== デバッグ用テスト実行完了 ===");
+            logger.info("=== Debug test run finished ===");
         }, delaySeconds, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
## Summary
- rewrite logger messages to English across client and server
- keep message content clear and consistent

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cc3b860308324903487aa86f1367a